### PR TITLE
Bump kotlinx datetime version

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -32,10 +32,13 @@ kotlin {
 
     sourceSets {
         all {
-            languageSettings.optIn("kotlin.experimental.ExperimentalObjCName")
+            languageSettings {
+                optIn("kotlin.experimental.ExperimentalObjCName")
+                optIn("kotlin.time.ExperimentalTime")
+            }
         }
         commonMain.dependencies {
-            implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
+            implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.7.1")
             implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
             implementation("io.ktor:ktor-client-core:${ktorVersion}")
             implementation("io.ktor:ktor-client-content-negotiation:${ktorVersion}")

--- a/shared/src/commonMain/kotlin/com/jetbrains/greeting/greetingkmp/NewYear.kt
+++ b/shared/src/commonMain/kotlin/com/jetbrains/greeting/greetingkmp/NewYear.kt
@@ -1,6 +1,7 @@
 package com.jetbrains.greeting.greetingkmp
 
 import kotlinx.datetime.*
+import kotlin.time.Clock
 
 fun daysUntilNewYear(): Int {
     val today = Clock.System.todayIn(TimeZone.currentSystemDefault())

--- a/shared/src/commonMain/kotlin/com/jetbrains/greeting/greetingkmp/RocketComponent.kt
+++ b/shared/src/commonMain/kotlin/com/jetbrains/greeting/greetingkmp/RocketComponent.kt
@@ -5,10 +5,10 @@ import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.get
 import io.ktor.serialization.kotlinx.json.*
-import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.json.Json
+import kotlin.time.Instant
 
 class RocketComponent {
     private val httpClient = HttpClient {
@@ -28,7 +28,7 @@ class RocketComponent {
         val date = Instant.parse(lastSuccessLaunch.launchDateUTC)
             .toLocalDateTime(TimeZone.currentSystemDefault())
 
-        return "${date.month} ${date.dayOfMonth}, ${date.year}"
+        return "${date.month} ${date.day}, ${date.year}"
     }
 
     suspend fun launchPhrase(): String =


### PR DESCRIPTION
kotlinx-datetime introduced a [breaking change](https://github.com/Kotlin/kotlinx-datetime/releases/tag/v0.7.0) to `Instant` and `Clock` 