### PR TITLE
fix: align with the SKIE version

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -15,7 +15,7 @@ struct ContentView: View {
 extension ContentView {
     @MainActor
     class ViewModel: ObservableObject {
-        @Published var greetings: Array<String> = []
+        @Published var greetings: [String] = []
 
         func startObserving() async {
             do {


### PR DESCRIPTION
`[String]` and `Array<String>` seem to be functionally equivalent, so I'm aligning the versions to avoid unnecessary differences between library branches.